### PR TITLE
Importing libipvs to compile with newer kernels.

### DIFF
--- a/libipvs/ip_vs.h
+++ b/libipvs/ip_vs.h
@@ -195,6 +195,22 @@ struct ip_vs_stats_user
 	__u32			outbps;		/* current out byte rate */
 };
 
+/*
+ *	IPVS statistics object (for user space), 64-bit
+ */
+struct ip_vs_stats64 {
+	__u64			conns;		/* connections scheduled */
+	__u64			inpkts;		/* incoming packets */
+	__u64			outpkts;	/* outgoing packets */
+	__u64			inbytes;	/* incoming bytes */
+	__u64			outbytes;	/* outgoing bytes */
+
+	__u64			cps;		/* current connection rate */
+	__u64			inpps;		/* current in packet rate */
+	__u64			outpps;		/* current out packet rate */
+	__u64			inbps;		/* current in byte rate */
+	__u64			outbps;		/* current out byte rate */
+};
 
 /* The argument to IP_VS_SO_GET_INFO */
 struct ip_vs_getinfo {
@@ -253,6 +269,8 @@ struct ip_vs_service_entry {
 	union nf_inet_addr	addr;
 	char			pe_name[IP_VS_PENAME_MAXLEN];
 
+	/* statistics, 64-bit */
+	struct ip_vs_stats64	stats64;
 };
 
 struct ip_vs_dest_entry_kern {
@@ -289,6 +307,9 @@ struct ip_vs_dest_entry {
 	struct ip_vs_stats_user stats;
 	u_int16_t		af;
 	union nf_inet_addr	addr;
+
+	/* statistics, 64-bit */
+	struct ip_vs_stats64	stats64;
 };
 
 /* The argument to IP_VS_SO_GET_DESTS */
@@ -348,6 +369,17 @@ struct ip_vs_timeout_user {
 
 
 /* The argument to IP_VS_SO_GET_DAEMON */
+struct ip_vs_daemon_kern {
+	/* sync daemon state (master/backup) */
+	int			state;
+
+	/* multicast interface name */
+	char			mcast_ifn[IP_VS_IFNAME_MAXLEN];
+
+	/* SyncID we belong to */
+	int			syncid;
+};
+
 struct ip_vs_daemon_user {
 	/* sync daemon state (master/backup) */
 	int			state;
@@ -357,6 +389,21 @@ struct ip_vs_daemon_user {
 
 	/* SyncID we belong to */
 	int			syncid;
+
+	/* UDP Payload Size */
+	int			sync_maxlen;
+
+	/* Multicast Port (base) */
+	u_int16_t		mcast_port;
+
+	/* Multicast TTL */
+	u_int16_t		mcast_ttl;
+
+	/* Multicast Address Family */
+	u_int16_t		mcast_af;
+
+	/* Multicast Address */
+	union nf_inet_addr	mcast_group;
 };
 
 
@@ -444,6 +491,8 @@ enum {
 
 	IPVS_SVC_ATTR_PE_NAME,		/* name of scheduler */
 
+	IPVS_SVC_ATTR_STATS64,		/* nested attribute for service stats */
+
 	__IPVS_SVC_ATTR_MAX,
 };
 
@@ -473,6 +522,8 @@ enum {
 
 	IPVS_DEST_ATTR_ADDR_FAMILY,	/* Address family of address */
 
+	IPVS_DEST_ATTR_STATS64,		/* nested attribute for dest stats */
+
 	__IPVS_DEST_ATTR_MAX,
 };
 
@@ -488,6 +539,11 @@ enum {
 	IPVS_DAEMON_ATTR_STATE,		/* sync daemon state (master/backup) */
 	IPVS_DAEMON_ATTR_MCAST_IFN,	/* multicast interface name */
 	IPVS_DAEMON_ATTR_SYNC_ID,	/* SyncID we belong to */
+	IPVS_DAEMON_ATTR_SYNC_MAXLEN,	/* UDP Payload Size */
+	IPVS_DAEMON_ATTR_MCAST_GROUP,	/* IPv4 Multicast Address */
+	IPVS_DAEMON_ATTR_MCAST_GROUP6,	/* IPv6 Multicast Address */
+	IPVS_DAEMON_ATTR_MCAST_PORT,	/* Multicast Port (base) */
+	IPVS_DAEMON_ATTR_MCAST_TTL,	/* Multicast TTL */
 	__IPVS_DAEMON_ATTR_MAX,
 };
 
@@ -496,7 +552,8 @@ enum {
 /*
  * Attributes used to describe service or destination entry statistics
  *
- * Used inside nested attributes IPVS_SVC_ATTR_STATS and IPVS_DEST_ATTR_STATS
+ * Used inside nested attributes IPVS_SVC_ATTR_STATS, IPVS_DEST_ATTR_STATS,
+ * IPVS_SVC_ATTR_STATS64 and IPVS_DEST_ATTR_STATS64.
  */
 enum {
 	IPVS_STATS_ATTR_UNSPEC = 0,

--- a/libipvs/ip_vs_nl_policy.c
+++ b/libipvs/ip_vs_nl_policy.c
@@ -40,7 +40,6 @@ struct nla_policy ipvs_dest_policy[IPVS_DEST_ATTR_MAX + 1] = {
 	[IPVS_DEST_ATTR_INACT_CONNS]	= { .type = NLA_U32 },
 	[IPVS_DEST_ATTR_PERSIST_CONNS]	= { .type = NLA_U32 },
 	[IPVS_DEST_ATTR_STATS]		= { .type = NLA_NESTED },
-	[IPVS_DEST_ATTR_ADDR_FAMILY]	= { .type = NLA_U16 },
 };
 
 struct nla_policy ipvs_stats_policy[IPVS_STATS_ATTR_MAX + 1] = {
@@ -66,6 +65,12 @@ struct nla_policy ipvs_daemon_policy[IPVS_DAEMON_ATTR_MAX + 1] = {
 	[IPVS_DAEMON_ATTR_MCAST_IFN]	= { .type = NLA_STRING,
 					    .maxlen = IP_VS_IFNAME_MAXLEN },
 	[IPVS_DAEMON_ATTR_SYNC_ID]	= { .type = NLA_U32 },
+	[IPVS_DAEMON_ATTR_SYNC_MAXLEN]	= { .type = NLA_U16 },
+	[IPVS_DAEMON_ATTR_MCAST_GROUP]	= { .type = NLA_U32 },
+	[IPVS_DAEMON_ATTR_MCAST_GROUP6]	= { .type = NLA_UNSPEC,
+					    .maxlen = sizeof(struct in6_addr) },
+	[IPVS_DAEMON_ATTR_MCAST_PORT]	= { .type = NLA_U16 },
+	[IPVS_DAEMON_ATTR_MCAST_TTL]	= { .type = NLA_U8 },
 };
 
 #endif /* LIBIPVS_USE_NL */

--- a/surealived/common.c
+++ b/surealived/common.c
@@ -23,7 +23,7 @@ static gchar *rstatestr[] = { "ONLINE", "OFFLINE", "DOWN", NULL };
 static gchar *nstatestr[] = { "UNKNOWN", "UP", "DOWN", NULL };
 static GHashTable *VCfgHash = NULL;
 
-inline void time_inc(struct timeval *t, guint s, guint ms) {
+void time_inc(struct timeval *t, guint s, guint ms) {
     guint usd;
 
     usd = t->tv_usec + ms*1000;

--- a/surealived/common.h
+++ b/surealived/common.h
@@ -39,7 +39,7 @@
 #include <sd_maincfg.h>
 #include <logging.h>
 
-inline void time_inc(struct timeval *, guint, guint);
+void time_inc(struct timeval *, guint, guint);
 
 #ifndef MAXPATHLEN
 #define MAXPATHLEN 512

--- a/surealived/sd_epoll.c
+++ b/surealived/sd_epoll.c
@@ -67,11 +67,11 @@ int sd_epoll_wait(SDepoll *epoll, int timeout) {
     return nr_events;
 }
 
-inline void *sd_epoll_event_dataptr(SDepoll *epoll, int i) {
+void *sd_epoll_event_dataptr(SDepoll *epoll, int i) {
     return epoll->events[i].data.ptr;
 }
 
-inline uint32_t  sd_epoll_event_events(SDepoll *epoll, int i) {
+uint32_t  sd_epoll_event_events(SDepoll *epoll, int i) {
     return epoll->events[i].events;
 }
 

--- a/surealived/sd_epoll.h
+++ b/surealived/sd_epoll.h
@@ -39,7 +39,7 @@ void            sd_epoll_ctl(SDepoll *epoll, int ctl, int fd, void *ptr, uint32_
 int             sd_epoll_wait(SDepoll *epoll, int timeout);
 gchar          *sd_epoll_event_str(uint32_t ev, gchar *buf);
 
-inline void    *sd_epoll_event_dataptr(SDepoll *epoll, int i);
-inline uint32_t sd_epoll_event_events(SDepoll *epoll, int i);
+void           *sd_epoll_event_dataptr(SDepoll *epoll, int i);
+uint32_t        sd_epoll_event_events(SDepoll *epoll, int i);
 
 #endif

--- a/surealived/sd_tester.c
+++ b/surealived/sd_tester.c
@@ -522,7 +522,7 @@ static void sd_tester_process_virt(gpointer virtptr, gpointer dataptr) {
     }
 }
 
-inline gboolean sd_tester_loop(SDTester *sdtest) {
+gboolean sd_tester_loop(SDTester *sdtest) {
     struct timeval ctime;
 
     if (sdtest && sdtest->VCfgArr) {

--- a/surealived/xmlparser.c
+++ b/surealived/xmlparser.c
@@ -310,7 +310,7 @@ static gint sd_parse_real(CfgVirtual *virt, xmlNode *node) {
     return 0;
 }
 
-inline void free_tester(CfgTester *t) {
+void free_tester(CfgTester *t) {
     if (!t)
         return;
     LOGDEBUG("Freeing tester: %s", t->proto);


### PR DESCRIPTION
Removing function inlining to avoid compile warnings and errors
if -Wall is used.

Signed-off-by: Zbigniew Kempczynski <wegorz76@gmail.com>